### PR TITLE
Support GNU Assembler and LD features on GBA GCC

### DIFF
--- a/packages/toolchain-gcc-arm-none-eabi-gcc/PKGBUILD
+++ b/packages/toolchain-gcc-arm-none-eabi-gcc/PKGBUILD
@@ -5,7 +5,7 @@
 pkgrel=4
 epoch=1
 GCC_TARGET=arm-none-eabi
-GCC_EXTRA_ARGS=(--enable-languages=c,c++,lto --enable-lto --enable-interwork --enable-multilib --enable-tls)
+GCC_EXTRA_ARGS=(--enable-languages=c,c++,lto --enable-lto --enable-interwork --enable-multilib --enable-tls --with-gnu-as --with-gnu-ld)
 
 . "../templates/toolchain-gcc-gcc13.PKGBUILD"
 


### PR DESCRIPTION
Some projects, such as the [GBA Minimal Runtime](https://github.com/LunarLambda/sdk-seven/tree/main/minrt) leverage GNU assembler syntax and features (`--with-gnu-as`).

An example is
```asm
.include "macros.inc"
```

Additionally, one must add the `--with-gnu-ld` configure flag to ensure LD passes all required flags to the assembler.

With both these features configured, `arm-none-eabi-gcc` can compile minrt, libseven, and other sdk-seven components.

I understand these are actively used in some homebrew games on the scene.